### PR TITLE
Update clojure to 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,16 @@ the installation).
 
 In each of the projects, clj/cfml and clj/tasks, run the **cfmljure** tests:
 
-	lein clean, deps, test
+	lein do clean, deps, test, jar
 
 You should see (with a different file path, I expect):
 
-	Cleaning up.
-	Copying 2 files to /Developer/tomcat-ws/lib/clj/cfml/lib
-	Testing cfml.test.examples
-	Ran 7 tests containing 7 assertions.
-	0 failures, 0 errors.
+    lein test cfml.test.examples
+    Ran 7 tests containing 7 assertions.
+    0 failures, 0 errors.
+    Created C:\Users\amyers\projects\cfmljure\clj\cfml\target\cfml-1.0.0-SNAPSHOT.jar
 
-Now you can copy the two Clojure JARs from the **clj/cfml/lib/** folder to your server's classpath.
-In your **WEB-INF** folder, create a **classes** folder and copy **clj/cfml**
-and **clj/task** to that **classes** folder. Restart your CFML engine.
-Now go hit the cfmljure **index.cfm** file in your browser!
+Now you can copy the JAR from the **clj/cfml/target/** folder to your server's classpath ( **WEB_INF/lib** ).  You will also need to copy clojure-1.5.1.jar to this location. In your **WEB-INF** folder, create a **classes** folder and copy **clj/cfml** and **clj/task** to that **classes** folder. Restart your CFML engine. Now go hit the cfmljure **index.cfm** file in your browser!
 
 # Your Clojure Code
 

--- a/clj/cfml/project.clj
+++ b/clj/cfml/project.clj
@@ -1,5 +1,4 @@
 (defproject cfml "1.0.0-SNAPSHOT"
   :description "cfmljure example project"
   :dependencies
-    [[org.clojure/clojure "1.2.0"]
-     [org.clojure/clojure-contrib "1.2.0"]])
+    [[org.clojure/clojure "1.5.1"]])

--- a/clj/task/project.clj
+++ b/clj/task/project.clj
@@ -1,6 +1,5 @@
-(defproject task "1.0.0-SNAPSHOT"
+( defproject task "1.0.0-SNAPSHOT"
   :description "FIXME: write"
-  :dependencies [[org.clojure/clojure "1.2.0"]
-                 [org.clojure/clojure-contrib "1.2.0"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.apache.derby/derby "10.6.1.0"]
-                 [clj-sql "0.0.4"]])
+                 [org.clojure/java.jdbc "0.2.3"]])

--- a/clj/task/src/task/core.clj
+++ b/clj/task/src/task/core.clj
@@ -1,5 +1,5 @@
 (ns task.core
-  (:use [clj-sql.core :as sql])
+  (:use [clojure.java.jdbc :as sql :only (with-connection with-query-results insert-record)])
   (:use [task.db])
   (:use [clojure.string :as s :only (lower-case upper-case)]))
 

--- a/clj/task/src/task/create.clj
+++ b/clj/task/src/task/create.clj
@@ -1,5 +1,5 @@
 (ns task.create
-  (:use [clj-sql.core :as sql])
+  (:use [clojure.java.jdbc :as sql :only (with-connection create-table drop-table)])
   (:use [task.db]))
 
 (defn create-tables []

--- a/clj/task/test/task/test/core.clj
+++ b/clj/task/test/task/test/core.clj
@@ -6,8 +6,8 @@
 (deftest add-test
   (binding [*err* nil] (drop-tables)) ;; ensure tables do not exist & suppress exception output
   (create-tables)
-  (is (= 1 (add-task "First task")))
-  (is (= 2 (add-task "Second task")))
+  (is (= 1 (int (:1 (add-task "First task")))))
+  (is (= 2 (int (:1 (add-task "Second task")))))
   (let [tasks (get-all :task)
         ids (set (map :id tasks))]
     (is (= 2 (count tasks)))
@@ -16,8 +16,8 @@
 (deftest get-by-id-test
   (binding [*err* nil] (drop-tables)) ;; ensure tables do not exist & suppress exception output
   (create-tables)
-  (is (= 1 (add-task "First task")))
-  (is (= 2 (add-task "Second task")))
+  (is (= 1 (int (:1 (add-task "First task")))))
+  (is (= 2 (int (:1 (add-task "Second task")))))
   (let [t1 (get-by-id :task 1)
         t2 (get-by-id :task 2 identity)]
     (is (= 1 (:id t1)))


### PR DESCRIPTION
Hi Sean,

I've had a go at upgrading cfmljure to use clojure 1.5.1 and org.clojure/java.jdbc 0.2.3.  I have also updated the README instructions for lein 2.

I had to modify the tests slightly as it appears that the return from sql/insert-record (which I note is deprecated but I wasn't sure what to use in its place?) is different to what it was in clj-sql.core.

Regards,
Andrew.
